### PR TITLE
Add logging output

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -4,9 +4,12 @@ Copyright © 2023 Kairo de Araujo <kairo@dearaujo.nl>
 package cmd
 
 import (
+	stdlog "log"
 	"os"
 
+	"github.com/go-logr/stdr"
 	"github.com/kairoaraujo/tufie/internal/storage"
+	"github.com/theupdateframework/go-tuf/v2/metadata"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -27,8 +30,9 @@ type Config struct {
 }
 
 var (
-	cfgFile string
-	Storage storage.TufiStorageService
+	cfgFile   string
+	verbosity bool
+	Storage   storage.TufiStorageService
 
 	TUFie = &cobra.Command{
 		Use:           "tufie",
@@ -55,6 +59,7 @@ func init() {
 	TUFie.PersistentFlags().StringVarP(
 		&cfgFile, "config", "c", "", "config file (default is $HOME/.tufie/config.yaml)",
 	)
+	TUFie.PersistentFlags().BoolVarP(&verbosity, "verbose", "v", false, "verbose output")
 	err := viper.BindPFlag("config", TUFie.PersistentFlags().Lookup("config"))
 	cobra.CheckErr(err)
 
@@ -64,6 +69,11 @@ func init() {
 }
 
 func InitConfig() {
+	metadata.SetLogger(stdr.New(stdlog.New(os.Stdout, "metadata - ", stdlog.LstdFlags)))
+	if verbosity {
+		stdr.SetVerbosity(5)
+	}
+
 	tufBaseDir, err := Storage.GetBaseDir()
 	cobra.CheckErr(err)
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/kairoaraujo/tufie
 go 1.21
 
 require (
+	github.com/go-logr/stdr v1.2.2
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.9.0
@@ -12,6 +13,7 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
+	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/google/go-containerregistry v0.19.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,9 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
-github.com/go-logr/logr v1.3.0 h1:2y3SDp0ZXuc6/cjLSZ+Q3ir+QB9T/iG5yYRXqsagWSY=
-github.com/go-logr/logr v1.3.0/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
+github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+github.com/go-logr/logr v1.4.1 h1:pKouT5E8xu9zeFC39JXRDukb6JFQPXM5p5I91188VAQ=
+github.com/go-logr/logr v1.4.1/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/go-test/deep v1.1.0 h1:WOcxcdHcvdgThNXjw0t76K42FXTU7HpNQWHpA2HHNlg=


### PR DESCRIPTION
This PR add the capability to use the --verbose flag and get the go-tuf logging output to be put on stdout. The implementation is inspired by the go-tuf example cli.